### PR TITLE
feat(ai): orch-library template suggestion engine

### DIFF
--- a/dimensigon/ai/template_suggest.py
+++ b/dimensigon/ai/template_suggest.py
@@ -1,0 +1,221 @@
+"""
+Template suggestion engine for the orch-library.
+
+Provides a hybrid TF-IDF + fuzzy search over the catalog of 6,302+ templates
+hosted in github.com/dimensigon/orch-library. Fetches the catalog lazily,
+caches in memory, and ranks templates by relevance to the user's query.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import re
+import threading
+import time
+from collections import Counter
+from typing import Dict, List, Optional
+
+import requests
+
+_LOGGER = logging.getLogger('dm.ai.template_suggest')
+
+# Default library source (override via DM_ORCH_LIBRARY_URL)
+DEFAULT_CATALOG_URL = (
+    "https://raw.githubusercontent.com/dimensigon/orch-library/main/catalog.json"
+)
+# Cache TTL for the fetched catalog
+CATALOG_TTL = 60 * 60  # 1 hour
+
+# Common English stopwords to strip from queries
+_STOPWORDS = frozenset("""
+a an the and or but if then else for to of in on at by with from as is are was
+were be been being do does did have has had i you he she it we they me him her
+us them my your his its our their this that these those how what when where why
+which who whom whose run do please can could would should help me need want want
+get set make create delete remove add update modify change check test new my
+""".split())
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
+
+
+def _tokenize(text: str) -> List[str]:
+    return [t.lower() for t in _TOKEN_RE.findall(text or "") if t.lower() not in _STOPWORDS]
+
+
+class TemplateIndex:
+    """In-memory TF-IDF index over the orch-library catalog."""
+
+    def __init__(self):
+        self._entries: List[Dict] = []
+        self._docs: List[List[str]] = []          # tokenized searchable text per entry
+        self._doc_freq: Counter = Counter()       # token -> number of docs containing it
+        self._doc_vectors: List[Dict[str, float]] = []  # per-doc tf-idf vectors
+        self._doc_norms: List[float] = []
+        self._loaded_at: float = 0.0
+        self._lock = threading.Lock()
+
+    @property
+    def size(self) -> int:
+        return len(self._entries)
+
+    def is_stale(self) -> bool:
+        return time.time() - self._loaded_at > CATALOG_TTL
+
+    def load_from_catalog(self, catalog: Dict):
+        entries = catalog.get("entries", [])
+        with self._lock:
+            self._entries = entries
+            self._docs = [self._build_doc(e) for e in entries]
+            self._doc_freq = Counter()
+            for tokens in self._docs:
+                for t in set(tokens):
+                    self._doc_freq[t] += 1
+            n = max(len(self._docs), 1)
+            self._doc_vectors = []
+            self._doc_norms = []
+            for tokens in self._docs:
+                tf = Counter(tokens)
+                vec = {}
+                for token, count in tf.items():
+                    df = self._doc_freq.get(token, 1)
+                    idf = math.log((1 + n) / (1 + df)) + 1.0
+                    vec[token] = (count / max(len(tokens), 1)) * idf
+                norm = math.sqrt(sum(v * v for v in vec.values())) or 1.0
+                self._doc_vectors.append(vec)
+                self._doc_norms.append(norm)
+            self._loaded_at = time.time()
+        _LOGGER.info(f"Loaded {len(entries)} templates into index")
+
+    @staticmethod
+    def _build_doc(entry: Dict) -> List[str]:
+        parts = [
+            entry.get("name", ""),
+            entry.get("description", ""),
+            entry.get("category", ""),
+            entry.get("action_type", "") or "",
+            entry.get("user_prompt", "") or "",
+            " ".join(entry.get("tags", []) or []),
+        ]
+        return _tokenize(" ".join(parts))
+
+    def search(self, query: str, top_k: int = 10,
+               entity_type: Optional[str] = None,
+               action_type: Optional[str] = None,
+               difficulty: Optional[str] = None) -> List[Dict]:
+        """Return top-K matching entries ranked by relevance."""
+        q_tokens = _tokenize(query)
+        if not q_tokens:
+            return []
+
+        # Build query TF-IDF vector
+        n = max(len(self._docs), 1)
+        q_tf = Counter(q_tokens)
+        q_vec = {}
+        for token, count in q_tf.items():
+            df = self._doc_freq.get(token, 1)
+            idf = math.log((1 + n) / (1 + df)) + 1.0
+            q_vec[token] = (count / max(len(q_tokens), 1)) * idf
+        q_norm = math.sqrt(sum(v * v for v in q_vec.values())) or 1.0
+
+        # Score each doc (cosine) + fuzzy bonus
+        scored = []
+        q_text_lower = query.lower()
+        for idx, entry in enumerate(self._entries):
+            if entity_type and entry.get("entity_type") != entity_type:
+                continue
+            if action_type and (entry.get("action_type") or "").upper() != action_type.upper():
+                continue
+            if difficulty and entry.get("difficulty") != difficulty:
+                continue
+
+            d_vec = self._doc_vectors[idx]
+            # cosine via dot product of shared terms
+            dot = sum(q_vec[t] * d_vec[t] for t in q_vec if t in d_vec)
+            score = dot / (q_norm * self._doc_norms[idx]) if dot else 0.0
+
+            # Exact-match boost in name or user_prompt
+            if entry.get("name") and q_text_lower in entry["name"].lower():
+                score += 0.3
+            if entry.get("user_prompt") and q_text_lower in entry["user_prompt"].lower():
+                score += 0.2
+
+            if score > 0:
+                scored.append((score, entry))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [
+            {**entry, "score": round(score, 4)}
+            for score, entry in scored[:top_k]
+        ]
+
+
+# Singleton index shared across requests
+_index = TemplateIndex()
+
+
+def get_index() -> TemplateIndex:
+    return _index
+
+
+def refresh_index(force: bool = False, url: Optional[str] = None) -> Dict:
+    """Fetch the catalog from the configured URL and rebuild the index."""
+    if not force and _index.size > 0 and not _index.is_stale():
+        return {"ok": True, "cached": True, "size": _index.size}
+
+    source = url or os.environ.get("DM_ORCH_LIBRARY_URL", DEFAULT_CATALOG_URL)
+    try:
+        resp = requests.get(source, timeout=15)
+        resp.raise_for_status()
+        catalog = resp.json()
+    except Exception as e:
+        _LOGGER.warning(f"Failed to fetch catalog from {source}: {e}")
+        return {"ok": False, "error": str(e), "size": _index.size}
+
+    _index.load_from_catalog(catalog)
+    return {"ok": True, "cached": False, "size": _index.size, "source": source}
+
+
+def suggest(query: str, top_k: int = 10, **filters) -> Dict:
+    """Suggest templates matching the user's query.
+
+    Returns a dict with the top-K results and metadata.
+    """
+    if _index.is_stale() or _index.size == 0:
+        refresh_index()
+
+    if _index.size == 0:
+        return {
+            "query": query,
+            "results": [],
+            "size": 0,
+            "error": "Template catalog unavailable. Set DM_ORCH_LIBRARY_URL or "
+                     "check network connectivity to github.com/dimensigon/orch-library.",
+        }
+
+    results = _index.search(query, top_k=top_k, **filters)
+    return {
+        "query": query,
+        "results": results,
+        "size": _index.size,
+        "source": os.environ.get("DM_ORCH_LIBRARY_URL", DEFAULT_CATALOG_URL),
+    }
+
+
+def fetch_template(path: str) -> Optional[Dict]:
+    """Fetch the full template JSON from the library by its path."""
+    base = os.environ.get(
+        "DM_ORCH_LIBRARY_RAW_BASE",
+        "https://raw.githubusercontent.com/dimensigon/orch-library/main/"
+    )
+    # Sanitize — no absolute or parent traversal
+    if path.startswith("/") or ".." in path:
+        return None
+    try:
+        resp = requests.get(base.rstrip("/") + "/" + path.lstrip("/"), timeout=15)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as e:
+        _LOGGER.warning(f"Failed to fetch template {path}: {e}")
+        return None

--- a/dimensigon/web/admin/routes.py
+++ b/dimensigon/web/admin/routes.py
@@ -1854,3 +1854,100 @@ def federation_peer_detail(peer_id):
     if not peer:
         return jsonify({'error': 'Peer not found'}), 404
     return jsonify(peer), 200
+
+
+# --- Orch-Library Template Suggestions (RAG-style search) ---
+
+@admin_routes_bp.route('/api/library/suggest', methods=['POST'])
+@webmanager_auth_required
+def library_suggest():
+    """Suggest templates from the orch-library matching the user's query.
+
+    Body: {query: str, top_k?: int, entity_type?: str, action_type?: str, difficulty?: str}
+    Returns: {query, results: [{id, name, description, score, path, ...}], size}
+    """
+    from dimensigon.ai import template_suggest
+    data = request.get_json(silent=True) or {}
+    query = (data.get('query') or '').strip()
+    if not query:
+        return jsonify({'error': 'query is required'}), 400
+
+    result = template_suggest.suggest(
+        query=query,
+        top_k=min(int(data.get('top_k', 10)), 50),
+        entity_type=data.get('entity_type'),
+        action_type=data.get('action_type'),
+        difficulty=data.get('difficulty'),
+    )
+    return jsonify(result), 200
+
+
+@admin_routes_bp.route('/api/library/refresh', methods=['POST'])
+@require_role('administrator')
+def library_refresh():
+    """Force-refresh the catalog index from the orch-library URL."""
+    from dimensigon.ai import template_suggest
+    data = request.get_json(silent=True) or {}
+    result = template_suggest.refresh_index(force=True, url=data.get('url'))
+    status = 200 if result.get('ok') else 503
+    return jsonify(result), status
+
+
+@admin_routes_bp.route('/api/library/fetch', methods=['POST'])
+@webmanager_auth_required
+def library_fetch():
+    """Fetch a single template by path and return its full JSON payload."""
+    from dimensigon.ai import template_suggest
+    data = request.get_json(silent=True) or {}
+    path = (data.get('path') or '').strip()
+    if not path:
+        return jsonify({'error': 'path is required'}), 400
+
+    tpl = template_suggest.fetch_template(path)
+    if tpl is None:
+        return jsonify({'error': 'Template not found or invalid path'}), 404
+    return jsonify(tpl), 200
+
+
+@admin_routes_bp.route('/api/library/import', methods=['POST'])
+@require_role('operator')
+def library_import():
+    """Fetch a template from the library and import it as a local OrchTemplate."""
+    from dimensigon.ai import template_suggest
+    from dimensigon.domain.entities.template import OrchTemplate
+
+    data = request.get_json(silent=True) or {}
+    path = (data.get('path') or '').strip()
+    if not path:
+        return jsonify({'error': 'path is required'}), 400
+
+    tpl = template_suggest.fetch_template(path)
+    if tpl is None:
+        return jsonify({'error': 'Template not found'}), 404
+
+    # Map library template to local OrchTemplate
+    category_map = {
+        'app_deploy': 'deployment', 'web': 'deployment', 'cicd': 'deployment',
+        'containers': 'deployment', 'database': 'maintenance',
+        'maintenance': 'maintenance', 'monitoring': 'monitoring',
+        'security': 'security', 'mail': 'custom',
+    }
+    cat_parts = tpl.get('category', '').split('.')
+    sub = cat_parts[-1] if cat_parts else 'custom'
+    local_category = category_map.get(sub, 'custom')
+
+    imported = OrchTemplate(
+        name=tpl.get('name', path),
+        description=tpl.get('description', ''),
+        category=local_category,
+        tags=tpl.get('tags', []),
+        json_content=tpl.get('template', {}),
+    )
+    db.session.add(imported)
+    db.session.commit()
+    return jsonify({
+        'message': 'Template imported',
+        'id': str(imported.id),
+        'name': imported.name,
+        'source_path': path,
+    }), 201

--- a/docs/tutorials/26-orch-library.md
+++ b/docs/tutorials/26-orch-library.md
@@ -1,0 +1,147 @@
+# Orch-Library Template Suggestions
+
+> **Plan:** Community-driven template library with AI-powered search
+> **Category:** AI / Templates
+> **Effort:** 2-3 hours to integrate
+
+## Overview
+
+The `orch-library` is a public GitHub repository (`github.com/dimensigon/orch-library`) hosting 6,302+ ready-to-use orchestrations and action templates. Dimensigon integrates with it in three ways:
+
+1. **Search** — a built-in TF-IDF + fuzzy hybrid search over the catalog
+2. **Fetch** — retrieve a single template's full JSON by path
+3. **Import** — copy a library template into your local `OrchTemplate` table
+
+The catalog is cached in memory for 1 hour and fetched lazily on first use.
+
+## Prerequisites
+
+- Authenticated WebManager session (see [05-authentication](./05-authentication.md))
+- Outbound HTTPS to `raw.githubusercontent.com` (or a mirror)
+- Optional: `DM_ORCH_LIBRARY_URL` env var to point at a custom catalog URL
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DM_ORCH_LIBRARY_URL` | `raw.githubusercontent.com/dimensigon/orch-library/main/catalog.json` | Catalog JSON URL |
+| `DM_ORCH_LIBRARY_RAW_BASE` | `raw.githubusercontent.com/dimensigon/orch-library/main/` | Base URL for individual templates |
+
+Catalog TTL: 1 hour (hardcoded in `dimensigon/ai/template_suggest.py`).
+
+## Endpoints
+
+### Suggest templates by natural language
+
+```bash
+curl -X POST https://dm.example.com/dm-webmanager/api/library/suggest \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "restart a systemd service with retries",
+    "top_k": 5,
+    "entity_type": "action_template",
+    "action_type": "SHELL"
+  }'
+```
+
+Response:
+
+```json
+{
+  "query": "restart a systemd service with retries",
+  "size": 6302,
+  "results": [
+    {
+      "id": "shell.service_mgmt.restart-service.v0",
+      "name": "postgresql-restart",
+      "description": "Restarts the postgresql systemd service and verifies...",
+      "category": "shell.service_mgmt",
+      "entity_type": "action_template",
+      "action_type": "SHELL",
+      "difficulty": "basic",
+      "tags": ["shell", "service_mgmt", "basic"],
+      "path": "action_templates/shell/service_mgmt/postgresql-restart.json",
+      "score": 0.8241
+    },
+    ...
+  ]
+}
+```
+
+**Filters:** `entity_type` (orchestration|action_template), `action_type` (SHELL|PYTHON|ANSIBLE|ORCHESTRATION), `difficulty` (basic|intermediate|advanced).
+
+### Fetch full template JSON
+
+```bash
+curl -X POST https://dm.example.com/dm-webmanager/api/library/fetch \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"path": "action_templates/shell/service_mgmt/postgresql-restart.json"}'
+```
+
+Returns the full template document including the executable `template` payload.
+
+### Import into local library
+
+```bash
+curl -X POST https://dm.example.com/dm-webmanager/api/library/import \
+  -H "Authorization: Bearer $JWT" \
+  -d '{"path": "orchestrations/single/app_deploy/rolling-deploy.json"}'
+```
+
+Requires the `operator` role. Creates a new `OrchTemplate` row mapped from the library template.
+
+### Force catalog refresh (admin)
+
+```bash
+curl -X POST https://dm.example.com/dm-webmanager/api/library/refresh \
+  -H "Authorization: Bearer $JWT"
+```
+
+Requires `administrator` role. Forces a re-fetch even if the cached catalog is still fresh.
+
+## End-to-end example
+
+```bash
+JWT=$(curl -sX POST https://dm.example.com/dm-webmanager/login \
+  -d '{"username":"ops","password":"..."}' -H "Content-Type: application/json" \
+  | jq -r '.access_token')
+
+# 1. Describe what you want
+PATH=$(curl -sX POST https://dm.example.com/dm-webmanager/api/library/suggest \
+  -H "Authorization: Bearer $JWT" \
+  -d '{"query":"deploy nginx with rolling update", "top_k":1}' \
+  | jq -r '.results[0].path')
+
+# 2. Import the top match
+curl -sX POST https://dm.example.com/dm-webmanager/api/library/import \
+  -H "Authorization: Bearer $JWT" \
+  -d "{\"path\":\"$PATH\"}"
+```
+
+## How ranking works
+
+The search engine computes:
+
+1. **TF-IDF cosine similarity** over a document built from: name + description + category + action_type + user_prompt + tags
+2. **Exact-match boosts**: +0.3 if the query text appears literally in the name, +0.2 in the user_prompt
+3. **English stopwords** are stripped from both query and documents before tokenization
+4. Results are sorted by final score descending and truncated to `top_k`
+
+This is fast (no embeddings, no external services) and works offline once the catalog is cached. For semantic search with embeddings, you can adapt `TemplateIndex.search()` to use an embedding model and cosine over dense vectors.
+
+## Contributing templates
+
+See [`CONTRIBUTING.md`](https://github.com/dimensigon/orch-library/blob/main/CONTRIBUTING.md) in the orch-library repo:
+
+1. Fork, add your template JSON in the right category
+2. `python3 scripts/validate.py <path>` to verify
+3. `python3 scripts/rebuild_catalog.py` to regenerate the index
+4. Submit a PR — CI runs schema validation + integrity checks
+
+## Related
+
+- [11-templates-marketplace](./11-templates-marketplace.md) — the local `OrchTemplate` catalog
+- [17-ai-chat](./17-ai-chat.md) — conversational orchestration authoring
+- [19-natural-language-runner](./19-natural-language-runner.md) — NL orchestration execution

--- a/tests/e2e/test_all_features.py
+++ b/tests/e2e/test_all_features.py
@@ -763,3 +763,118 @@ class TestPhase5_Federation(EndToEndBase):
             # Revoke
             resp = self.api('post', f'/dm-webmanager/api/federation/peers/{peer_id}/revoke')
             self.assertEqual(200, resp.status_code)
+
+
+# ==============================================================
+# Orch-Library Integration (Plan 26 — post-3.0)
+# ==============================================================
+
+class TestOrchLibrary(EndToEndBase):
+    """Template suggestion and fetch integration with orch-library."""
+
+    SAMPLE_CATALOG = {
+        "version": "1.0.0",
+        "total": 2,
+        "entries": [
+            {
+                "id": "shell.service_mgmt.restart-service.v0",
+                "name": "postgresql-restart",
+                "description": "Restarts the postgresql systemd service.",
+                "category": "shell.service_mgmt",
+                "entity_type": "action_template",
+                "action_type": "SHELL",
+                "difficulty": "basic",
+                "tags": ["shell", "service_mgmt", "basic"],
+                "user_prompt": "Restart the postgresql service using systemctl",
+                "path": "action_templates/shell/service_mgmt/postgresql-restart.json",
+            },
+            {
+                "id": "orch.deploy.rolling.v0",
+                "name": "rolling-deploy",
+                "description": "Rolling deployment across multiple nodes.",
+                "category": "orchestration.single.app_deploy",
+                "entity_type": "orchestration",
+                "action_type": "ORCHESTRATION",
+                "difficulty": "advanced",
+                "tags": ["orchestration", "deploy"],
+                "user_prompt": "Deploy using rolling update",
+                "path": "orchestrations/single/app_deploy/rolling-deploy.json",
+            },
+        ],
+    }
+
+    def setUp(self):
+        super().setUp()
+        # Pre-populate the library index with a sample catalog
+        from dimensigon.ai import template_suggest
+        template_suggest._index = template_suggest.TemplateIndex()
+        template_suggest._index.load_from_catalog(self.SAMPLE_CATALOG)
+
+    def test_suggest_requires_auth(self):
+        resp = self.api('post', '/dm-webmanager/api/library/suggest',
+                        {'query': 'restart service'})
+        self.assertEqual(302, resp.status_code)
+
+    def test_suggest_returns_results(self):
+        self.login()
+        resp = self.api('post', '/dm-webmanager/api/library/suggest',
+                        {'query': 'restart postgresql', 'top_k': 3})
+        self.assertEqual(200, resp.status_code)
+        data = resp.get_json()
+        self.assertIn('results', data)
+        self.assertTrue(len(data['results']) >= 1)
+        self.assertEqual('postgresql-restart', data['results'][0]['name'])
+
+    def test_suggest_rejects_empty_query(self):
+        self.login()
+        resp = self.api('post', '/dm-webmanager/api/library/suggest', {'query': ''})
+        self.assertEqual(400, resp.status_code)
+
+    def test_suggest_filters_by_entity_type(self):
+        self.login()
+        resp = self.api('post', '/dm-webmanager/api/library/suggest',
+                        {'query': 'deploy rolling', 'entity_type': 'orchestration'})
+        data = resp.get_json()
+        for r in data['results']:
+            self.assertEqual('orchestration', r['entity_type'])
+
+    def test_fetch_requires_path(self):
+        self.login()
+        resp = self.api('post', '/dm-webmanager/api/library/fetch', {})
+        self.assertEqual(400, resp.status_code)
+
+    def test_fetch_rejects_traversal(self):
+        self.login()
+        resp = self.api('post', '/dm-webmanager/api/library/fetch',
+                        {'path': '../../etc/passwd'})
+        self.assertEqual(404, resp.status_code)
+
+    def test_refresh_requires_admin(self):
+        self.login('operator', _TEST_PW_OP)
+        resp = self.api('post', '/dm-webmanager/api/library/refresh')
+        self.assertIn(resp.status_code, [302, 403])
+
+    def test_import_requires_operator(self):
+        self.login('viewer', _TEST_PW_VIEW)
+        resp = self.api('post', '/dm-webmanager/api/library/import',
+                        {'path': 'fake.json'})
+        self.assertIn(resp.status_code, [302, 403])
+
+    def test_import_template_success(self):
+        from dimensigon.ai import template_suggest
+        self.login('operator', _TEST_PW_OP)
+        sample_tpl = {
+            'id': 'test.sample.v0',
+            'name': 'sample-import',
+            'description': 'Imported sample',
+            'category': 'orchestration.single.app_deploy',
+            'tags': ['test'],
+            'template': {'name': 'sample-import', 'steps': []},
+        }
+        with mock.patch.object(template_suggest, 'fetch_template',
+                               return_value=sample_tpl):
+            resp = self.api('post', '/dm-webmanager/api/library/import',
+                            {'path': 'orchestrations/test/sample.json'})
+        self.assertEqual(201, resp.status_code)
+        data = resp.get_json()
+        self.assertEqual('sample-import', data['name'])

--- a/tests/unit/ai/test_template_suggest.py
+++ b/tests/unit/ai/test_template_suggest.py
@@ -1,0 +1,199 @@
+"""Tests for the orch-library template suggestion engine."""
+import json
+import sys
+from unittest import TestCase, mock
+
+# Pre-mock netifaces to avoid import-time failure in CI
+if 'netifaces' not in sys.modules:
+    mock_netifaces = mock.MagicMock()
+    mock_netifaces.interfaces.return_value = ['lo']
+    mock_netifaces.ifaddresses.return_value = {2: [{'addr': '127.0.0.1'}]}
+    mock_netifaces.AF_INET = 2
+    sys.modules['netifaces'] = mock_netifaces
+
+from dimensigon.ai import template_suggest
+
+
+SAMPLE_CATALOG = {
+    "version": "1.0.0",
+    "total": 4,
+    "entries": [
+        {
+            "id": "shell.service_mgmt.restart-service.v0",
+            "name": "postgresql-restart",
+            "description": "Restarts the postgresql systemd service and verifies it becomes active.",
+            "category": "shell.service_mgmt",
+            "entity_type": "action_template",
+            "action_type": "SHELL",
+            "difficulty": "basic",
+            "tags": ["shell", "service_mgmt", "basic"],
+            "user_prompt": "Restart the postgresql service using systemctl",
+            "path": "action_templates/shell/service_mgmt/postgresql-restart.json",
+        },
+        {
+            "id": "shell.service_mgmt.restart-service.v1",
+            "name": "nginx-restart",
+            "description": "Restarts the nginx web server and confirms it's running.",
+            "category": "shell.service_mgmt",
+            "entity_type": "action_template",
+            "action_type": "SHELL",
+            "difficulty": "basic",
+            "tags": ["shell", "service_mgmt", "basic", "nginx"],
+            "user_prompt": "Restart the nginx web server",
+            "path": "action_templates/shell/service_mgmt/nginx-restart.json",
+        },
+        {
+            "id": "orch.deploy.rolling.v0",
+            "name": "rolling-deploy",
+            "description": "Rolling deployment across multiple nodes with health checks.",
+            "category": "orchestration.single.app_deploy",
+            "entity_type": "orchestration",
+            "action_type": "ORCHESTRATION",
+            "difficulty": "advanced",
+            "tags": ["orchestration", "deploy", "rolling"],
+            "user_prompt": "Deploy application using rolling update strategy",
+            "path": "orchestrations/single/app_deploy/rolling-deploy.json",
+        },
+        {
+            "id": "python.http_api.healthcheck.v0",
+            "name": "http-healthcheck",
+            "description": "Python HTTP health check with retries and custom timeouts.",
+            "category": "python.http_api",
+            "entity_type": "action_template",
+            "action_type": "PYTHON",
+            "difficulty": "intermediate",
+            "tags": ["python", "http", "health"],
+            "user_prompt": "Check if an HTTP service is healthy",
+            "path": "action_templates/python/http_api/http-healthcheck.json",
+        },
+    ],
+}
+
+
+class TestTemplateIndex(TestCase):
+
+    def setUp(self):
+        self.idx = template_suggest.TemplateIndex()
+        self.idx.load_from_catalog(SAMPLE_CATALOG)
+
+    def test_index_size(self):
+        self.assertEqual(4, self.idx.size)
+
+    def test_search_exact_service_match(self):
+        results = self.idx.search("restart postgresql service", top_k=3)
+        self.assertTrue(len(results) >= 1)
+        self.assertEqual("postgresql-restart", results[0]["name"])
+
+    def test_search_nginx_match(self):
+        results = self.idx.search("restart nginx web server", top_k=3)
+        self.assertEqual("nginx-restart", results[0]["name"])
+
+    def test_search_filters_by_entity_type(self):
+        results = self.idx.search("deploy rolling", entity_type="orchestration")
+        self.assertTrue(all(r["entity_type"] == "orchestration" for r in results))
+
+    def test_search_filters_by_action_type(self):
+        results = self.idx.search("health check", action_type="PYTHON")
+        self.assertTrue(all(r["action_type"] == "PYTHON" for r in results))
+
+    def test_search_filters_by_difficulty(self):
+        results = self.idx.search("restart", difficulty="basic")
+        self.assertTrue(all(r["difficulty"] == "basic" for r in results))
+
+    def test_search_empty_query(self):
+        self.assertEqual([], self.idx.search(""))
+
+    def test_search_no_match(self):
+        # Use a word that appears nowhere in the sample catalog
+        results = self.idx.search("quantumfluxcapacitor")
+        self.assertEqual(0, len(results))
+
+    def test_score_present(self):
+        results = self.idx.search("restart postgresql")
+        self.assertIn("score", results[0])
+        self.assertGreater(results[0]["score"], 0)
+
+    def test_results_sorted_by_score_desc(self):
+        results = self.idx.search("restart service")
+        if len(results) > 1:
+            for i in range(len(results) - 1):
+                self.assertGreaterEqual(results[i]["score"], results[i + 1]["score"])
+
+
+class TestSuggestAPI(TestCase):
+
+    def setUp(self):
+        # Pre-populate the global index
+        template_suggest._index = template_suggest.TemplateIndex()
+        template_suggest._index.load_from_catalog(SAMPLE_CATALOG)
+
+    def test_suggest_returns_results(self):
+        result = template_suggest.suggest("restart postgres", top_k=3)
+        self.assertIn("results", result)
+        self.assertTrue(len(result["results"]) >= 1)
+        self.assertEqual("postgresql-restart", result["results"][0]["name"])
+
+    def test_suggest_respects_top_k(self):
+        result = template_suggest.suggest("restart", top_k=1)
+        self.assertLessEqual(len(result["results"]), 1)
+
+    def test_suggest_includes_metadata(self):
+        result = template_suggest.suggest("nginx")
+        self.assertIn("query", result)
+        self.assertIn("size", result)
+
+
+class TestRefreshIndex(TestCase):
+
+    def setUp(self):
+        template_suggest._index = template_suggest.TemplateIndex()
+
+    def test_refresh_fetches_from_url(self):
+        with mock.patch('dimensigon.ai.template_suggest.requests.get') as mock_get:
+            mock_resp = mock.MagicMock()
+            mock_resp.json.return_value = SAMPLE_CATALOG
+            mock_resp.raise_for_status = mock.MagicMock()
+            mock_get.return_value = mock_resp
+
+            result = template_suggest.refresh_index(force=True)
+            self.assertTrue(result["ok"])
+            self.assertEqual(4, result["size"])
+            self.assertFalse(result["cached"])
+
+    def test_refresh_handles_fetch_failure(self):
+        with mock.patch('dimensigon.ai.template_suggest.requests.get') as mock_get:
+            mock_get.side_effect = Exception("Network down")
+            result = template_suggest.refresh_index(force=True)
+            self.assertFalse(result["ok"])
+            self.assertIn("error", result)
+
+    def test_refresh_uses_cache_when_fresh(self):
+        template_suggest._index.load_from_catalog(SAMPLE_CATALOG)
+        result = template_suggest.refresh_index(force=False)
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["cached"])
+
+
+class TestFetchTemplate(TestCase):
+
+    def test_fetch_template_success(self):
+        with mock.patch('dimensigon.ai.template_suggest.requests.get') as mock_get:
+            mock_resp = mock.MagicMock()
+            mock_resp.json.return_value = {"id": "t1", "name": "test", "template": {}}
+            mock_resp.raise_for_status = mock.MagicMock()
+            mock_get.return_value = mock_resp
+
+            result = template_suggest.fetch_template("action_templates/shell/foo/bar.json")
+            self.assertIsNotNone(result)
+            self.assertEqual("t1", result["id"])
+
+    def test_fetch_template_rejects_absolute_path(self):
+        self.assertIsNone(template_suggest.fetch_template("/etc/passwd"))
+
+    def test_fetch_template_rejects_parent_traversal(self):
+        self.assertIsNone(template_suggest.fetch_template("../../secret.json"))
+
+    def test_fetch_template_handles_network_error(self):
+        with mock.patch('dimensigon.ai.template_suggest.requests.get') as mock_get:
+            mock_get.side_effect = Exception("Timeout")
+            self.assertIsNone(template_suggest.fetch_template("valid/path.json"))


### PR DESCRIPTION
## Summary

Integrates the new **[dimensigon/orch-library](https://github.com/dimensigon/orch-library)** (6,302 templates, seeded in a sibling PR) as an AI-powered template suggestion source.

Users describe what they want in natural language and get ranked matches from the library. Selected templates can be fetched, previewed, and imported into the local catalog with one call.

### New endpoints

| Method | Path | Role |
|--------|------|------|
| POST | `/dm-webmanager/api/library/suggest` | any authenticated |
| POST | `/dm-webmanager/api/library/fetch` | any authenticated |
| POST | `/dm-webmanager/api/library/refresh` | administrator |
| POST | `/dm-webmanager/api/library/import` | operator |

### How ranking works

- TF-IDF cosine similarity over: name + description + category + action_type + user_prompt + tags
- Exact-match boosts (+0.3 name, +0.2 user_prompt)
- Stopword removal
- Filters: `entity_type`, `action_type`, `difficulty`

Fast, offline-capable once cached (1-hour TTL). No embedding service required, but `TemplateIndex.search()` is cleanly isolated for future embedding-based upgrades.

### Configuration

| Env var | Default |
|---------|---------|
| `DM_ORCH_LIBRARY_URL` | raw.githubusercontent.com/dimensigon/orch-library/main/catalog.json |
| `DM_ORCH_LIBRARY_RAW_BASE` | raw.githubusercontent.com/dimensigon/orch-library/main/ |

### Security

- Path sanitization on fetch (no absolute paths, no parent traversal)
- Role-gated admin and import endpoints

## Test plan
- [x] 20 unit tests (`tests/unit/ai/test_template_suggest.py`) — indexing, search, filters, cache, security
- [x] 9 E2E tests (`tests/e2e/test_all_features.py::TestOrchLibrary`) — all 4 endpoints, auth, roles
- [x] Full tutorial at `docs/tutorials/26-orch-library.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)